### PR TITLE
debian: adjust for a Jammy package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: syslog-canary
 Maintainer: Vincent Bernat <bernat@debian.org>
-Build-Depends: debhelper (>= 9),
-               lsb-release,
-               dh-systemd
+Build-Depends: debhelper (>= 9.20160709) | dh-systemd,
+               lsb-release
 
 Package: syslog-canary
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -9,3 +9,6 @@ DEBVERSION = $(VERSION)-0~$(DISTRIBUTION)0
 
 override_dh_gencontrol:
 	dh_gencontrol -- -$(DEBVERSION)
+
+override_dh_builddeb:
+	dh_builddeb -- -Zxz


### PR DESCRIPTION
Make sure that we use a dpkg compression accepted by Aptly as well as take care of the redundant `dh-systemd` build dependency.