### PR TITLE
debian: allow python3 as runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,4 +6,5 @@ Build-Depends: debhelper (>= 9.20160709) | dh-systemd,
 Package: syslog-canary
 Architecture: all
 Description: monitor /dev/log and restart syslog daemon on failures
-Depends: ${misc:Depends}, python
+Depends: ${misc:Depends},
+         python | python3


### PR DESCRIPTION
There's no python package in Jammy; use python3 as runtime dependency
instead. syslog-canary is python3 ready anyway.