### PR TITLE
Switch to python3 execution

### DIFF
--- a/syslog-canary
+++ b/syslog-canary
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Canary for syslog.
 


### PR DESCRIPTION
There's no python in Ubuntu Jammy. The code is python3 ready so
we should be fine explicitly switching to python3.